### PR TITLE
Fire an event before cache is cleared to allow tasks to be triggered first

### DIFF
--- a/Console/ClearCommand.php
+++ b/Console/ClearCommand.php
@@ -56,6 +56,8 @@ class ClearCommand extends Command {
 	 */
 	public function fire()
 	{
+		$this->laravel['events']->fire('cache:preclear');
+
 		$this->cache->flush();
 
 		$this->files->delete($this->laravel['config']['app.manifest'].'/services.json');


### PR DESCRIPTION
Signed-off-by: Ben James in@benjam.es
