### PR TITLE
Remove a tiny bit of redundant code

### DIFF
--- a/CacheManager.php
+++ b/CacheManager.php
@@ -199,7 +199,7 @@ class CacheManager implements FactoryContract
     {
         $redis = $this->app['redis'];
 
-        $connection = array_get($config, 'connection', 'default') ?: 'default';
+        $connection = array_get($config, 'connection', 'default');
 
         return $this->repository(new RedisStore($redis, $this->getPrefix($config), $connection));
     }


### PR DESCRIPTION
Was just browsing through sources. Notices the sweet `array_get` function which seems to support a default parameter as used here. So it seems to be it's a bit redundant when combined with the elvis operator