### PR TITLE
Cache items dependencies

### DIFF
--- a/RateLimiting/Limit.php
+++ b/RateLimiting/Limit.php
@@ -7,7 +7,7 @@ class Limit
     /**
      * The rate limit signature key.
      *
-     * @var mixed|string
+     * @var mixed
      */
     public $key;
 
@@ -35,7 +35,7 @@ class Limit
     /**
      * Create a new limit instance.
      *
-     * @param  mixed|string  $key
+     * @param  mixed  $key
      * @param  int  $maxAttempts
      * @param  int  $decayMinutes
      * @return void
@@ -107,7 +107,7 @@ class Limit
     /**
      * Set the key of the rate limit.
      *
-     * @param  string  $key
+     * @param  mixed  $key
      * @return $this
      */
     public function by($key)


### PR DESCRIPTION
In this PR request I would like to introduce the cache dependencies.
The main purpose of cache dependencies is to create connection of various cache items with each other by specific identifiers. This functionality is intended to help with simple work with the invalidation of cache records that chain each other. The programmer does not have to remember all the names of the cache  keys or the exact sequence of cache tags from which he wants to delete cached items. You just have to set dependencies and invalidate them.

Cache dependencies usage example:

When storing records in the cache, you can set the dependencies like:
Cache::dependencies('my_cache_dependency')->set('test_item', 1);
Cache::tags(['taggroup_1', 'taggroup_2'])->dependencies('my_cache_dependency')->set('test_item', 1);

Altought setting more dependencies for cached item is supported, you just have to set them as an array:
Cache::dependencies(['my_cache_dependency', 'another_cache_dependency'])->set('test_item', 1);

Or you can set dependencies as key, value: (this case is useful if you want to chain cache dependency to specific identifier/s from database)
Cache::dependencies(['product' => [1])->set('test_item', 1);
Cache::dependencies(['product' => [1, 2, 3, ..etc])->set('test_item', 1);

If you want to invalidate (remove) all the records from the cache that have dependencies, you can use following code:
Cache::dependencies('my_cache_dependency')->invalidate();

If you have any questions or suggestions, let me know.
Thank you!