### PR TITLE
Fix `unserialize(): Argument #1 ($data) must be of type string`

### DIFF
--- a/RedisStore.php
+++ b/RedisStore.php
@@ -419,6 +419,10 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     protected function unserialize($value)
     {
+        if ($value instanceof \Redis) {
+            return $value;
+        }
+        
         return is_numeric($value) ? $value : unserialize($value);
     }
 }


### PR DESCRIPTION
When using Laravel batch with Redis, this issue will show up

```
local.ERROR: unserialize(): Argument #1 ($data) must be of type string, Redis given {"exception":"[object] (TypeError(code: 0): unserialize(): Argument #1 ($data) must be of type string, Redis given at
```

This PR will resolve the issue